### PR TITLE
Decorrelate strategy and selection

### DIFF
--- a/Analysis/calcYields.py
+++ b/Analysis/calcYields.py
@@ -26,8 +26,9 @@ submission_parser.add_argument('--batchSystem', action='store',         default=
 submission_parser.add_argument('--dryRun',   action='store_true', default=False,  help='do not launch subjobs, only show them')
 submission_parser.add_argument('--coupling', type = float, action='store', default=0.01,  help='Coupling of the sample')
 submission_parser.add_argument('--noskim', action='store_true', default=False,  help='Use no skim sample list')
-submission_parser.add_argument('--selection',   action='store', default='cutbased',  help='Select the strategy to use to separate signal from background', choices=['cutbased', 'AN2017014', 'MVA', 'Luka'])
-submission_parser.add_argument('--region',   action='store', default='baseline',  help='apply the cuts of high or low mass regions, use "all" to run both simultaniously', 
+submission_parser.add_argument('--selection',   action='store', default='default',  help='Select the type of selection for objects', choices=['leptonMVAtop', 'AN2017014', 'default', 'Luka', 'TTT'])
+submission_parser.add_argument('--strategy',   action='store', default='cutbased',  help='Select the strategy to use to separate signal from background', choices=['cutbased', 'MVA'])
+submission_parser.add_argument('--region',   action='store', default='baseline',  help='Choose the selection region', 
     choices=['baseline', 'highMassSR', 'lowMassSR', 'ZZ', 'WZ', 'ConversionCR'])
 submission_parser.add_argument('--includeData',   action='store_true', default=False,  help='Also run over data samples')
 submission_parser.add_argument('--customList',  action='store',      default=None,               help='Name of a custom sample list. Otherwise it will use the appropriate noskim file.')
@@ -173,6 +174,8 @@ if not args.makePlots and args.makeDataCards is None:
 
         chain.HNLmass = sample.getMass()
         chain.year = int(args.year)
+        chain.selection = args.selection
+        chain.strategy = args.strategy
 
         #
         # Get luminosity weight
@@ -189,7 +192,7 @@ if not args.makePlots and args.makeDataCards is None:
         from HNL.ObjectSelection.objectSelection import getObjectSelection
         chain.obj_sel = getObjectSelection(args.selection)
 
-        es = EventSelector(args.region, chain, chain, args.selection, True, ec)
+        es = EventSelector(args.region, chain, chain, True, ec)
 
         list_of_numbers = {}
         for c in listOfCategories(args.region):
@@ -202,9 +205,9 @@ if not args.makePlots and args.makeDataCards is None:
 
         def getOutputName(prompt_string):
             if not args.isTest:
-                output_string = os.path.join(os.path.expandvars('$CMSSW_BASE'), 'src', 'HNL', 'Analysis', 'data', __file__.split('.')[0].rsplit('/')[-1], args.year, args.selection, args.region, sample.output, prompt_string)
+                output_string = os.path.join(os.path.expandvars('$CMSSW_BASE'), 'src', 'HNL', 'Analysis', 'data', __file__.split('.')[0].rsplit('/')[-1], args.year, args.strategy, args.selection, args.region, sample.output, prompt_string)
             else:
-                output_string = os.path.join(os.path.expandvars('$CMSSW_BASE'), 'src', 'HNL', 'Analysis', 'data', 'testArea', __file__.split('.')[0].rsplit('/')[-1], args.year, args.selection, args.region, sample.output, prompt_string)
+                output_string = os.path.join(os.path.expandvars('$CMSSW_BASE'), 'src', 'HNL', 'Analysis', 'data', 'testArea', __file__.split('.')[0].rsplit('/')[-1], args.year, args.strategy, args.selection, args.region, sample.output, prompt_string)
 
             if args.isChild:
                 output_string += '/tmp_'+sample.output
@@ -278,9 +281,9 @@ else:
     # Check status of the jobs and merge
     #
     if not args.isTest:
-        base_path = os.path.join(os.path.expandvars('$CMSSW_BASE'), 'src', 'HNL', 'Analysis', 'data', __file__.split('.')[0].rsplit('/')[-1], args.year, args.selection, args.region)
+        base_path = os.path.join(os.path.expandvars('$CMSSW_BASE'), 'src', 'HNL', 'Analysis', 'data', __file__.split('.')[0].rsplit('/')[-1], args.year, args.strategy, args.selection, args.region)
     else:
-        base_path = os.path.join(os.path.expandvars('$CMSSW_BASE'), 'src', 'HNL', 'Analysis', 'data', 'testArea', __file__.split('.')[0].rsplit('/')[-1], args.year, args.selection, args.region)
+        base_path = os.path.join(os.path.expandvars('$CMSSW_BASE'), 'src', 'HNL', 'Analysis', 'data', 'testArea', __file__.split('.')[0].rsplit('/')[-1], args.year, args.strategy, args.selection, args.region)
 
     in_files = glob.glob(os.path.join(base_path, '*', '*'))
     merge(in_files, __file__, jobs, ('sample', 'subJob'), argParser, istest=args.isTest)

--- a/BackgroundEstimation/closureTest.py
+++ b/BackgroundEstimation/closureTest.py
@@ -29,7 +29,7 @@ submission_parser.add_argument('--splitInBJets', action='store_true', default=Fa
 submission_parser.add_argument('--inData',   action='store_true', default=False,  help='Run in data')
 submission_parser.add_argument('--region', action='store', default=None, type=str,  help='What region was the fake rate you want to use measured in?', 
     choices=['TauFakesDY', 'TauFakesTT', 'Mix'])
-submission_parser.add_argument('--selection',   action='store', default='MVA',  help='Select the strategy to use to separate signal from background', choices=['cut-based', 'AN2017014', 'MVA', 'ewkino', 'TTT', 'Luka'])
+submission_parser.add_argument('--selection',   action='store', default='default',  help='Select the type of selection for objects', choices=['leptonMVAtop', 'AN2017014', 'default', 'Luka', 'TTT'])
 submission_parser.add_argument('--logLevel',  action='store',      default='INFO',               help='Log level for logging', nargs='?', choices=['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE'])
 
 argParser.add_argument('--makePlots', action='store_true', default=False,  help='make plots')
@@ -61,7 +61,7 @@ if args.flavorToTest == ['tau']:
 
 if args.selection == 'AN2017014':
     raise RuntimeError("selection AN2017014 currently not supported")
-if args.splitInBJets and args.selection != 'cutbased' and args.selection != 'MVA':
+if args.splitInBJets and args.selection != 'default':
     raise RuntimeError("selection currently not supported in combination with splitInBJets")
 
 if args.inData and args.flavorToTest == 'ele' or args.flavorToTest == 'mu':
@@ -227,14 +227,14 @@ if not args.makePlots:
     from HNL.EventSelection.eventSelector import EventSelector
     if args.isCheck:
         if args.flavorToTest == ['tau']:
-            es = EventSelector('TauFakes', chain, chain, args.selection, True, ec, in_data = args.inData)    
+            es = EventSelector('TauFakes', chain, chain, True, ec, in_data = args.inData)    
         else:
             raise RuntimeError("Wrong input for flavorToTest with isCheck arg on: "+str(args.flavorToTest))
     else:
         if not args.inData:
-            es = EventSelector('MCCT', chain, chain, args.selection, True, ec, in_data = args.inData, additional_options=args.flavorToTest) 
+            es = EventSelector('MCCT', chain, chain, True, ec, in_data = args.inData, additional_options=args.flavorToTest) 
         else:
-            es = EventSelector('DataCT', chain, chain, args.selection, True, ec, in_data = args.inData, additional_options=args.flavorToTest) 
+            es = EventSelector('DataCT', chain, chain, True, ec, in_data = args.inData, additional_options=args.flavorToTest) 
 
     fakerate = {}
     if 'tau' in args.flavorToTest:

--- a/BackgroundEstimation/tightToLoose.py
+++ b/BackgroundEstimation/tightToLoose.py
@@ -20,7 +20,7 @@ submission_parser.add_argument('--inData',   action='store_true', default=False,
 submission_parser.add_argument('--batchSystem',   action='store', default='HTCondor',  help='help')
 submission_parser.add_argument('--dryRun',   action='store_true', default=False,  help='do not launch subjobs, only show them')
 submission_parser.add_argument('--noskim', action='store_true', default=False,  help='measure in data')
-submission_parser.add_argument('--selection',   action='store', default='MVA',  help='Select the strategy to use to separate signal from background', choices=['cut-based', 'AN2017014', 'MVA', 'ewkino', 'TTT', 'Luka'])
+submission_parser.add_argument('--selection',   action='store', default='default',  help='Select the type of selection for objects', choices=['leptonMVAtop', 'AN2017014', 'default', 'Luka', 'TTT'])
 submission_parser.add_argument('--tauRegion', action='store', type=str, default = None, help='What region do you want to select for?', 
     choices=['TauFakesDY', 'TauFakesTT'])
 submission_parser.add_argument('--logLevel',  action='store',      default='INFO',               help='Log level for logging', nargs='?', choices=['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE'])
@@ -185,7 +185,7 @@ if not args.makePlots:
     #
     # Define event selection
     #
-    es = EventSelector(region_to_select, chain, chain, args.selection, True, ec, in_data = args.inData)            
+    es = EventSelector(region_to_select, chain, chain, True, ec, in_data = args.inData)            
 
     #
     # Create fake rate objects

--- a/EventSelection/calcSignalEfficiency.py
+++ b/EventSelection/calcSignalEfficiency.py
@@ -24,7 +24,8 @@ submission_parser.add_argument('--subJob',   action='store',      default=None, 
 submission_parser.add_argument('--isTest',   action='store_true', default=False,  help='Run a small test')
 submission_parser.add_argument('--batchSystem', action='store',         default='HTCondor',  help='choose batchsystem', choices=['local', 'HTCondor', 'Cream02'])
 submission_parser.add_argument('--dryRun',   action='store_true', default=False,  help='do not launch subjobs, only show them')
-submission_parser.add_argument('--selection', action='store', default='cutbased', type=str,  help='What type of analysis do you want to run?', choices=['cutbased', 'AN2017014', 'MVA'])
+submission_parser.add_argument('--selection',   action='store', default='default',  help='Select the type of selection for objects', choices=['leptonMVAtop', 'AN2017014', 'default', 'Luka', 'TTT'])
+submission_parser.add_argument('--strategy',   action='store', default='cutbased',  help='Select the strategy to use to separate signal from background', choices=['cutbased', 'MVA'])
 submission_parser.add_argument('--region', action='store', default='baseline', type=str,  help='What region do you want to select for?', 
     choices=['baseline', 'lowMassSR', 'highMassSR'])
 submission_parser.add_argument('--FOcut',   action='store_true', default=False,  help='Perform baseline FO cut')
@@ -65,7 +66,7 @@ for sample_name in sample_manager.sample_names:
     for flavor in flavors:
         if not '-'+flavor+'-' in sample_name: continue
         sample = sample_manager.getSample(sample_name)
-        for njob in xrange(sample.split_jobs): 
+        for njob in xrange(sample.returnSplitJobs()): 
             jobs += [(sample.name, str(njob), flavor)]
 
 
@@ -110,7 +111,6 @@ else:
 # It assumes the samples are ordered by mass in the input list
 #
 from HNL.Tools.helpers import getMassRange
-print [sample_name for sample_name in sample_manager.sample_names if '-'+args.flavor+'-' in sample_name]
 mass_range = getMassRange([sample_name for sample_name in sample_manager.sample_names if '-'+args.flavor+'-' in sample_name])
 
 #
@@ -161,6 +161,8 @@ else:
 
 chain.HNLmass = sample.getMass()
 chain.year = int(args.year)
+chain.selection = args.selection
+chain.strategy = args.strategy
 
 #
 # Get luminosity weight
@@ -194,7 +196,7 @@ from HNL.ObjectSelection.objectSelection import getObjectSelection
 chain.obj_sel = getObjectSelection(args.selection)
 
 from HNL.EventSelection.eventSelector import EventSelector
-es = EventSelector(args.region, chain, chain, args.selection, True, ec)    
+es = EventSelector(args.region, chain, chain, True, ec)    
 
 for entry in event_range:
     

--- a/EventSelection/python/controlRegionSelector.py
+++ b/EventSelection/python/controlRegionSelector.py
@@ -5,11 +5,10 @@ from HNL.Tools.helpers import getFourVec, deltaPhi, deltaR
 
 class FilterObject(object):
 
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
         self.name = name
         self.chain = chain
         self.new_chain = new_chain
-        self.selection = selection
         self.is_reco_level = is_reco_level
         self.ec = event_categorization
 
@@ -18,14 +17,14 @@ class FilterObject(object):
             if not cutter.cut(selectLeptonsGeneral(self.chain, self.new_chain, nL, cutter=cutter, sort_leptons = sort_leptons), 'select leptons'): return False
         else:
             if not cutter.cut(selectGenLeptonsGeneral(self.chain, self.new_chain, nL, cutter=cutter), 'select leptons'): return False
-        calculateEventVariables(self.chain, self.new_chain, nL, is_reco_level=self.is_reco_level, selection=self.selection)
+        calculateEventVariables(self.chain, self.new_chain, nL, is_reco_level=self.is_reco_level)
         self.chain.category = max(cat.CATEGORIES)
         return True
 
 class ZZCRfilter(FilterObject):
     
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
-        super(ZZCRfilter, self).__init__(name, chain, new_chain, selection, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
+        super(ZZCRfilter, self).__init__(name, chain, new_chain, is_reco_level=True, event_categorization = None)
 
     def initEvent(self, cutter):
         return super(ZZCRfilter, self).initEvent(4, cutter, sort_leptons = True)
@@ -42,8 +41,8 @@ class ZZCRfilter(FilterObject):
 
 class WZCRfilter(FilterObject):
 
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
-        super(WZCRfilter, self).__init__(name, chain, new_chain, selection, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
+        super(WZCRfilter, self).__init__(name, chain, new_chain, is_reco_level=True, event_categorization = None)
 
     def initEvent(self, cutter):
         return super(WZCRfilter, self).initEvent(3, cutter, sort_leptons = True)
@@ -63,8 +62,8 @@ class WZCRfilter(FilterObject):
 
 class ConversionCRfilter(FilterObject):
 
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
-        super(ConversionCRfilter, self).__init__(name, chain, new_chain, selection, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
+        super(ConversionCRfilter, self).__init__(name, chain, new_chain, is_reco_level=True, event_categorization = None)
 
     def initEvent(self, cutter):
         return super(ConversionCRfilter, self).initEvent(3, cutter, sort_leptons = True)
@@ -74,15 +73,15 @@ class ConversionCRfilter(FilterObject):
         if not cutter.cut(containsOSSF(self.chain), 'OSSF present'):         return False
         if not cutter.cut(abs(self.new_chain.M3l-MZ) < 15, 'M3l_onZ'):       return False 
         if not cutter.cut(self.chain.MZossf < 75, 'Mll < 75'):               return False
-        if self.selection == 'AN2017014' and not cutter.cut(passesPtCutsAN2017014(chain), 'pt_cuts'):     return False 
+        if self.chain.selection == 'AN2017014' and not cutter.cut(passesPtCutsAN2017014(chain), 'pt_cuts'):     return False 
         if not cutter.cut(not bVeto(self.chain), 'b-veto'):                 return False
         self.chain.category = max(cat.CATEGORIES)
         return True
 
 class TauFakeEnrichedDY(FilterObject):
     
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
-        super(TauFakeEnrichedDY, self).__init__(name, chain, new_chain, selection, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
+        super(TauFakeEnrichedDY, self).__init__(name, chain, new_chain, is_reco_level=True, event_categorization = None)
 
     def initEvent(self, cutter):
         self.chain.obj_sel['tau_wp'] = 'FO'
@@ -112,8 +111,8 @@ class TauFakeEnrichedDY(FilterObject):
 
 class TauFakeEnrichedTT(FilterObject):
     
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
-        super(TauFakeEnrichedTT, self).__init__(name, chain, new_chain, selection, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
+        super(TauFakeEnrichedTT, self).__init__(name, chain, new_chain, is_reco_level=True, event_categorization = None)
 
     def initEvent(self, cutter):
         self.chain.obj_sel['tau_wp'] = 'FO'
@@ -148,8 +147,8 @@ from HNL.ObjectSelection.leptonSelector import isGoodLepton, isFakeLepton
 from HNL.EventSelection.eventSelectionTools import selectJets
 #Orthogonal due to selection of exactly 1 lepton
 class LightLeptonFakeMeasurementRegion(FilterObject):
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
-        super(LightLeptonFakeMeasurementRegion, self).__init__(name, chain, new_chain, selection, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
+        super(LightLeptonFakeMeasurementRegion, self).__init__(name, chain, new_chain, is_reco_level=True, event_categorization = None)
 
     def initEvent(self, cutter):
         self.chain.obj_sel['ele_wp'] = 'loose'
@@ -193,8 +192,8 @@ class LightLeptonFakeMeasurementRegion(FilterObject):
 # General Closure Test Selection class
 #
 class ClosureTestSelection(FilterObject):
-    def __init__(self, name, chain, new_chain, selection, flavor_of_interest, is_reco_level=True, event_categorization = None):
-        super(ClosureTestSelection, self).__init__(name, chain, new_chain, selection, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, flavor_of_interest, is_reco_level=True, event_categorization = None):
+        super(ClosureTestSelection, self).__init__(name, chain, new_chain, is_reco_level=True, event_categorization = None)
         self.flavor_of_interest = flavor_of_interest
         self.loose_leptons_of_interest = []
 
@@ -255,8 +254,8 @@ class ClosureTestSelection(FilterObject):
             return False
 
 class TauClosureTest(ClosureTestSelection):
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
-        super(TauClosureTest, self).__init__(name, chain, new_chain, selection, 2, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
+        super(TauClosureTest, self).__init__(name, chain, new_chain, 2, is_reco_level=True, event_categorization = None)
         self.chain.obj_sel['tau_wp'] = 'FO'
         self.chain.obj_sel['ele_wp'] = 'tight'
         self.chain.obj_sel['mu_wp'] = 'tight'
@@ -282,8 +281,8 @@ class TauClosureTest(ClosureTestSelection):
 from HNL.EventSelection.signalRegionSelector import SignalRegionSelector
 from HNL.EventSelection.eventSelectionTools import applyConeCorrection
 class ElectronClosureTest(ClosureTestSelection):
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
-        super(ElectronClosureTest, self).__init__(name, chain, new_chain, selection, 0, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
+        super(ElectronClosureTest, self).__init__(name, chain, new_chain, 0, is_reco_level=True, event_categorization = None)
         self.chain.obj_sel['tau_wp'] = 'tight'
         self.chain.obj_sel['ele_wp'] = 'FO'
         self.chain.obj_sel['mu_wp'] = 'tight'
@@ -299,8 +298,8 @@ class ElectronClosureTest(ClosureTestSelection):
         return True
 
 class MuonClosureTest(ClosureTestSelection):
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
-        super(MuonClosureTest, self).__init__(name, chain, new_chain, selection, 1, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
+        super(MuonClosureTest, self).__init__(name, chain, new_chain, 1, is_reco_level=True, event_categorization = None)
         self.chain.obj_sel['tau_wp'] = 'tight'
         self.chain.obj_sel['ele_wp'] = 'tight'
         self.chain.obj_sel['mu_wp'] = 'FO'
@@ -316,8 +315,8 @@ class MuonClosureTest(ClosureTestSelection):
         return True
 
 class LukaClosureTest(FilterObject):
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
-        super(LukaClosureTest, self).__init__(name, chain, new_chain, selection, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None):
+        super(LukaClosureTest, self).__init__(name, chain, new_chain, is_reco_level=True, event_categorization = None)
 
     def initEvent(self, cutter):
         self.chain.obj_sel['ele_wp'] = 'FO'
@@ -349,8 +348,8 @@ class LukaClosureTest(FilterObject):
 class ClosureTestMC(FilterObject):
     flavor_dict = {'tau' : 2, 'ele' : 0, 'mu' : 1}
 
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None, additional_options=None):
-        super(ClosureTestMC, self).__init__(name, chain, new_chain, selection, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None, additional_options=None):
+        super(ClosureTestMC, self).__init__(name, chain, new_chain, is_reco_level=True, event_categorization = None)
         self.flavors_of_interest = additional_options
         if self.flavors_of_interest is None: 
             raise RuntimeError('Input for ClosureTestMC for flavors_of_interest is None')
@@ -440,8 +439,8 @@ class ClosureTestMC(FilterObject):
 class ClosureTestDATA(FilterObject):
     flavor_dict = {'tau' : 2, 'ele' : 0, 'mu' : 1}
 
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization = None, additional_options=None):
-        super(ClosureTestDATA, self).__init__(name, chain, new_chain, selection, is_reco_level=True, event_categorization = None)
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization = None, additional_options=None):
+        super(ClosureTestDATA, self).__init__(name, chain, new_chain, is_reco_level=True, event_categorization = None)
         self.flavors_of_interest = additional_options
         if self.flavors_of_interest is None: 
             raise RuntimeError('Input for ClosureTestDATA for flavors_of_interest is None')

--- a/EventSelection/python/eventSelectionTools.py
+++ b/EventSelection/python/eventSelectionTools.py
@@ -163,7 +163,7 @@ def selectGenLeptonsGeneral(chain, new_chain, nL, cutter=None):
 #
 # Meant for training NN, select up to two jets, if less than two jets, 
 #
-def selectFirstTwoJets(chain, new_chain, selection = None):
+def selectFirstTwoJets(chain, new_chain):
     if chain is new_chain:
         new_chain.j_pt = [0.0]*2
         new_chain.j_eta = [0.0]*2
@@ -202,14 +202,14 @@ def selectFirstTwoJets(chain, new_chain, selection = None):
 # Function to calculate all kinematic variables to be used later on in the selection steps
 # All variables are stored in the chain so they can be called anywhere
 #
-def calculateEventVariables(chain, new_chain, nL = None, is_reco_level = True, selection = None):
-    calculateGeneralVariables(chain, new_chain, is_reco_level=is_reco_level, selection=selection)
+def calculateEventVariables(chain, new_chain, nL = None, is_reco_level = True):
+    calculateGeneralVariables(chain, new_chain, is_reco_level=is_reco_level)
     if nL == 3:
         calculateThreeLepVariables(chain, new_chain, is_reco_level = is_reco_level)
     if nL == 4:
         calculateFourLepVariables(chain, new_chain)
 
-def calculateGeneralVariables(chain, new_chain, is_reco_level = True, selection = None):
+def calculateGeneralVariables(chain, new_chain, is_reco_level = True):
     if is_reco_level:
         #ptCone
         new_chain.pt_cone = []
@@ -438,10 +438,10 @@ def selectJets(chain, cleaned = 'loose'):
         if isGoodJet(chain, jet, cleaned=cleaned): jet_indices.append(jet)
     return jet_indices
 
-def nBjets(chain, wp, selection = None):
+def nBjets(chain, wp):
     nbjets = 0
     for jet in xrange(chain._nJets):
-        if isGoodBJet(chain, jet, wp, selection = selection): nbjets += 1
+        if isGoodBJet(chain, jet, wp): nbjets += 1
     return nbjets
 
 def bVeto(chain):

--- a/EventSelection/python/eventSelector.py
+++ b/EventSelection/python/eventSelector.py
@@ -4,40 +4,39 @@ from HNL.EventSelection.controlRegionSelector import ZZCRfilter, WZCRfilter, Con
 
 class EventSelector:
 
-    def __init__(self, name, chain, new_chain, selection, is_reco_level=True, event_categorization=None, in_data=False, additional_options=None):
+    def __init__(self, name, chain, new_chain, is_reco_level=True, event_categorization=None, in_data=False, additional_options=None):
         self.name = name
-        self.selection = selection
         self.chain = chain
         self.new_chain = new_chain
         self.is_reco_level = is_reco_level
         if self.name in ['baseline', 'lowMassSR', 'highMassSR']:
             if in_data:
                 raise RuntimeError("Running this would mean unblinding. Dont do this.")
-            self.selector = SignalRegionSelector(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization)
+            self.selector = SignalRegionSelector(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization)
         elif self.name == 'ZZCR':
-            self.selector = ZZCRfilter(name, chain, new_chain, selection, is_reco_level=is_reco_level)
+            self.selector = ZZCRfilter(name, chain, new_chain, is_reco_level=is_reco_level)
         elif self.name == 'WZCR':
-            self.selector = WZCRfilter(name, chain, new_chain, selection, is_reco_level=is_reco_level)
+            self.selector = WZCRfilter(name, chain, new_chain, is_reco_level=is_reco_level)
         elif self.name == 'ConversionCR':
-            self.selector = ConversionCRfilter(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization)
+            self.selector = ConversionCRfilter(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization)
         elif self.name == 'TauFakesDY':
-            self.selector = TauFakeEnrichedDY(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization)
+            self.selector = TauFakeEnrichedDY(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization)
         elif self.name == 'TauFakesTT':
-            self.selector = TauFakeEnrichedTT(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization)
+            self.selector = TauFakeEnrichedTT(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization)
         elif self.name == 'LightLeptonFakes':
-            self.selector = LightLeptonFakeMeasurementRegion(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization)
+            self.selector = LightLeptonFakeMeasurementRegion(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization)
         elif self.name == 'TauCT':
-            self.selector = TauClosureTest(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization)
+            self.selector = TauClosureTest(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization)
         elif self.name == 'ElectronCT':
-            self.selector = ElectronClosureTest(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization)
+            self.selector = ElectronClosureTest(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization)
         elif self.name == 'MuonCT':
-            self.selector = MuonClosureTest(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization)
+            self.selector = MuonClosureTest(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization)
         elif self.name == 'LukaCT':
-            self.selector = LukaClosureTest(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization)
+            self.selector = LukaClosureTest(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization)
         elif self.name == 'MCCT':
-            self.selector = ClosureTestMC(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization, additional_options=additional_options)
+            self.selector = ClosureTestMC(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization, additional_options=additional_options)
         elif self.name == 'DataCT':
-            self.selector = ClosureTestDATA(name, chain, new_chain, selection, is_reco_level=is_reco_level, event_categorization = event_categorization, additional_options=additional_options)
+            self.selector = ClosureTestDATA(name, chain, new_chain, is_reco_level=is_reco_level, event_categorization = event_categorization, additional_options=additional_options)
 
     def passedFilter(self, cutter):
         return self.selector.passedFilter(cutter)

--- a/EventSelection/python/signalRegionSelector.py
+++ b/EventSelection/python/signalRegionSelector.py
@@ -8,9 +8,8 @@ l3 = 2
 
 class SignalRegionSelector:
 
-    def __init__(self, region, chain, new_chain, selection, is_reco_level=True, event_categorization = None):
+    def __init__(self, region, chain, new_chain, is_reco_level=True, event_categorization = None):
         self.region = region
-        self.selection = selection
         self.chain = chain
         self.new_chain = new_chain
         self.is_reco_level = is_reco_level
@@ -19,7 +18,7 @@ class SignalRegionSelector:
     def initEvent(self, cutter):
         if self.is_reco_level and not cutter.cut(est.select3Leptons(self.chain, self.new_chain, cutter=cutter), 'select leptons'): return False
         if not self.is_reco_level and not cutter.cut(est.selectGenLeptonsGeneral(self.chain, self.new_chain, 3, cutter=cutter), 'select leptons'): return False
-        est.calculateEventVariables(self.chain, self.new_chain, 3, is_reco_level=self.is_reco_level, selection=self.selection)
+        est.calculateEventVariables(self.chain, self.new_chain, 3, is_reco_level=self.is_reco_level)
         if self.ec is not None: self.chain.category = self.ec.returnCategory()
         return True
 
@@ -54,9 +53,9 @@ class SignalRegionSelector:
         return True
 
     def passBaseCuts(self, cutter):
-        if self.selection == 'AN2017014':
+        if self.chain.selection == 'AN2017014':
             return self.baseFilterAN2017(cutter)
-        elif self.selection == 'MVA':
+        elif self.chain.strategy == 'MVA':
             return self.baseFilterMVA(cutter)
         else:
             return self.baseFilterCutBased(cutter)
@@ -93,17 +92,23 @@ class SignalRegionSelector:
 
         if not self.passBaseCuts(cutter): return False
 
-        if self.selection != "MVA":
-            if self.region == 'lowMassSR':
-                return self.passLowMassSelection(cutter)
-            elif self.region == 'highMassSR':
-                return self.passHighMassSelection(cutter)
-            elif self.region == 'baseline':
-                return True
-        elif self.selection == "MVA":
+        # if self.chain.strategy != "MVA":
+        #     if self.region == 'lowMassSR':
+        #         return self.passLowMassSelection(cutter)
+        #     elif self.region == 'highMassSR':
+        #         return self.passHighMassSelection(cutter)
+        #     elif self.region == 'baseline':
+        #         return True
+        # elif self.chain.strategy == "MVA":
+        #     return True
+
+        if self.region == 'lowMassSR':
+            return self.passLowMassSelection(cutter)
+        elif self.region == 'highMassSR':
+            return self.passHighMassSelection(cutter)
+        elif self.region == 'baseline':
             return True
         else:
-            raise RuntimeError('Given signal region: "'+ self.region +'" not known')
-
+            raise RuntimeError("Unknown signal region: "+self.region)
 
     

--- a/ObjectSelection/compareLightLeptonId.py
+++ b/ObjectSelection/compareLightLeptonId.py
@@ -63,7 +63,7 @@ sample_manager = SampleManager(args.year, 'noskim', 'compareTauIdList_'+str(args
 jobs = []
 for sample_name in sample_manager.sample_names:
     sample = sample_manager.getSample(sample_name)
-    for njob in xrange(sample.split_jobs):
+    for njob in xrange(sample.returnSplitJobs()):
         jobs += [(sample.name, str(njob))]
 
 if not args.isChild:

--- a/ObjectSelection/compareTauID.py
+++ b/ObjectSelection/compareTauID.py
@@ -53,8 +53,8 @@ submission_parser.add_argument('--includeReco',   action='store', default=None,
 submission_parser.add_argument('--discriminators', nargs='*', default=['iso', 'ele','mu'],  help='Which discriminators do you want to test?', choices = ['iso', 'ele', 'mu'])
 submission_parser.add_argument('--makeCombinations', action='store_true', default=False,
     help='Makes combinations of iso with different electron and muon working points. Turned off by default because large hadd times for large samples.')
-args = argParser.parse_args()
 submission_parser.add_argument('--logLevel',  action='store',      default='INFO',               help='Log level for logging', nargs='?', choices=['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE'])
+args = argParser.parse_args()
 
 
 from HNL.Tools.logger import getLogger, closeLogger
@@ -153,7 +153,7 @@ sample_manager = SampleManager(args.year, 'noskim', 'compareTauIdList_'+str(args
 jobs = []
 for sample_name in sample_manager.sample_names:
     sample = sample_manager.getSample(sample_name)
-    for njob in xrange(sample.split_jobs):
+    for njob in xrange(sample.returnSplitJobs()):
         jobs += [(sample.name, str(njob))]
         
 if not args.isChild:
@@ -171,7 +171,7 @@ chain = sample.initTree(False)
 isBkgr = not 'HNL' in sample.name
 
 from HNL.ObjectSelection.objectSelection import getObjectSelection
-chain.obj_sel = getObjectSelection('MVA')
+chain.obj_sel = getObjectSelection('default')
 
 #
 # Function to show what gen status' should be allowed for different types of background

--- a/ObjectSelection/getSignificance.py
+++ b/ObjectSelection/getSignificance.py
@@ -67,7 +67,7 @@ from HNL.Tools.helpers import getFourVec
 jobs = []
 for sample_name in sample_manager.sample_names:
     sample = sample_manager.getSample(sample_name)
-    for njob in xrange(sample.split_jobs):
+    for njob in xrange(sample.returnSplitJobs()):
         jobs += [(sample.name, str(njob))]
 
 

--- a/ObjectSelection/python/objectSelection.py
+++ b/ObjectSelection/python/objectSelection.py
@@ -1,5 +1,5 @@
 default_tau_algo = 'HNL'
-default_light_algo = 'leptonMVAtop'
+default_light_algo = 'Luka'
 default_jet_selection = 'HNL'
 default_tau_wp = 'tight'
 default_ele_wp = 'tight'
@@ -21,11 +21,17 @@ def objectSelectionCollection(tau_algo = default_tau_algo, light_algo = default_
 
     return object_selection_collection
 
+#
+# Function for fixing object selection
+# "default" gives the selection decided on for the HNL analysis, other special selection have their respective names
+#
 def getObjectSelection(selection):
     object_selection = None
-    if selection == 'MVA' or selection == 'cutbased':
+    if selection == 'default':
         # object_selection = objectSelectionCollection(tau_algo='HNL', light_algo='leptonMVAtop', notau=False, analysis='HNL', jet_algo = 'HNL')         
-        object_selection = objectSelectionCollection(tau_algo='HNL', light_algo='Luka', analysis='HNL') 
+        object_selection = objectSelectionCollection() 
+    elif selection == 'leptonMVAtop':
+        object_selection = objectSelectionCollection(tau_algo='HNL', light_algo='leptonMVAtop', notau=False, analysis='HNL', jet_algo = 'HNL')         
     elif selection == 'AN2017014':
         object_selection = objectSelectionCollection(tau_algo='HNL', light_algo='cutbased', notau=True, analysis='HNL', jet_algo = 'AN2017014')          
     elif selection == 'ewkino':
@@ -33,7 +39,8 @@ def getObjectSelection(selection):
     elif selection == 'TTT':
         object_selection = objectSelectionCollection(tau_algo='HNL', light_algo='TTT', analysis='HNL', jet_algo = 'TTT')
     elif selection == 'Luka':
-        object_selection = objectSelectionCollection(tau_algo='HNL', light_algo='Luka', analysis='HNL', jet_algo = 'Luka')
+        # object_selection = objectSelectionCollection(tau_algo='HNL', light_algo='Luka', analysis='HNL', jet_algo = 'Luka')
+        object_selection = objectSelectionCollection(tau_algo='HNL', light_algo='Luka', analysis='HNL')
     else:
         print 'No valid selection parameter for object selection given, using defaults'
 

--- a/Samples/python/sampleManager.py
+++ b/Samples/python/sampleManager.py
@@ -24,7 +24,7 @@ SAMPLE_GROUPS = {
 class SampleManager:
 
 
-    def __init__(self, year, skim, sample_names_file, need_skim_samples):
+    def __init__(self, year, skim, sample_names_file, need_skim_samples=False):
         if not skim in ALLOWED_SKIMS:
             raise RuntimeError("skim "+skim+" not allowed in the sample manager")
 

--- a/TMVA/prepareTrees.py
+++ b/TMVA/prepareTrees.py
@@ -20,8 +20,8 @@ submission_parser.add_argument('--logLevel',  action='store',      default='INFO
 submission_parser.add_argument('--summaryFile', action='store_true', default=False,  help='Create text file that shows all selected arguments')
 submission_parser.add_argument('--noskim', action='store_true', default=False,  help='Use unskimmed files')
 submission_parser.add_argument('--customList',  action='store',      default=None,               help='Name of a custom sample list. Otherwise it will use the appropriate noskim file.')
-submission_parser.add_argument('--selection',   action='store', default='MVA',
-    help='Select the strategy to use to separate signal from background', choices=['cutbased', 'AN2017014', 'MVA'])
+submission_parser.add_argument('--selection',   action='store', default='default',  help='Select the type of selection for objects', choices=['leptonMVAtop', 'AN2017014', 'default', 'Luka', 'TTT'])
+submission_parser.add_argument('--strategy',   action='store', default='cutbased',  help='Select the strategy to use to separate signal from background', choices=['cutbased', 'MVA'])
 submission_parser.add_argument('--region',   action='store', default='baseline', 
     help='apply the cuts of high or low mass regions, use "all" to run both simultaniously', choices=['baseline', 'highMassSR', 'lowMassSR', 'ZZ', 'WZ', 'Conversion'])
 
@@ -84,6 +84,8 @@ if not args.merge:
     chain = sample.initTree(needhcount=False)
     chain.year = int(args.year)
     chain.is_signal = 'HNL' in sample.name
+    chain.selection = args.selection
+    chain.strategy = args.strategy
 
     reweighter = Reweighter(sample, sample_manager)
 
@@ -143,7 +145,7 @@ if not args.merge:
     #prepare object  and event selection
     from HNL.ObjectSelection.objectSelection import getObjectSelection
     chain.obj_sel = getObjectSelection(args.selection)
-    es = EventSelector(args.region, chain, chain, args.selection, True, ec)
+    es = EventSelector(args.region, chain, chain, True, ec)
 
     for entry in event_range:
         chain.GetEntry(entry)

--- a/Test/ditaumass.py
+++ b/Test/ditaumass.py
@@ -54,7 +54,7 @@ sample_manager = SampleManager(args.year, 'noskim', 'ditaumass_'+str(args.year))
 jobs = []
 for sample_name in sample_manager.sample_names:
     sample = sample_manager.getSample(sample_name)
-    for njob in xrange(sample.split_jobs): 
+    for njob in xrange(sample.returnSplitJobs()): 
         jobs += [(sample.name, str(njob))]
 
 if not args.makePlots:

--- a/Test/plotTauVar.py
+++ b/Test/plotTauVar.py
@@ -62,7 +62,7 @@ sample_manager = SampleManager(args.year, 'noskim', 'compareTauIdList_'+str(args
 jobs = []
 for sample_name in sample_manager.sample_names:
     sample = sample_manager.getSample(sample_name)
-    for njob in xrange(sample.split_jobs): 
+    for njob in xrange(sample.returnSplitJobs()): 
         jobs += [(sample.name, str(njob))]
 
 if not args.makePlots:

--- a/Test/signalCompression.py
+++ b/Test/signalCompression.py
@@ -41,7 +41,7 @@ if not args.isChild:
     for sample_name in sample_manager.sample_names:
         print sample_name
         sample = sample_manager.getSample(sample_name)        
-        for njob in xrange(sample.split_jobs): 
+        for njob in xrange(sample.returnSplitJobs()): 
             jobs += [(sample.name, str(njob))]
 
     submitJobs(__file__, ('sample', 'subJob'), jobs, argParser, jobLabel = 'compression')
@@ -89,7 +89,7 @@ from HNL.EventSelection.eventCategorization import EventCategory, filterSuperCat
 from HNL.EventSelection.signalLeptonMatcher import SignalLeptonMatcher
 slm = SignalLeptonMatcher(chain)
 ec = EventCategory(chain)
-es = EventSelector('baseline', chain, chain, 'MVA', is_reco_level = False, event_categorization=ec)
+es = EventSelector('baseline', chain, chain, is_reco_level = False, event_categorization=ec)
 
 #
 # Create cutter to provide cut flow

--- a/Triggers/calcTriggerEff.py
+++ b/Triggers/calcTriggerEff.py
@@ -52,7 +52,7 @@ sample_manager = SampleManager(args.year, 'noskim', 'triggerlist_'+str(args.year
 jobs = []
 for sample_name in sample_manager.sample_names:
     sample = sample_manager.getSample(sample_name)
-    for njob in xrange(sample.split_jobs): 
+    for njob in xrange(sample.returnSplitJobs()): 
         jobs += [(sample.name, str(njob))]
 
 #
@@ -201,7 +201,7 @@ else:
 
 #prepare object  and event selection
 from HNL.ObjectSelection.objectSelection import getObjectSelection
-chain.obj_sel = getObjectSelection('MVA') if not args.oldTriggers else getObjectSelection('AN2017014')
+chain.obj_sel = getObjectSelection('default') if not args.oldTriggers else getObjectSelection('AN2017014')
 
 #
 # Loop over all events


### PR DESCRIPTION
- Split the argument "selection" into two arguments "strategy" and "selection" as the original use was becoming ambiguous as different object selections were used for both cutbased and MVA methods.
- Adapted object selection to have a default for HNL and then named options for special cases
- Removed "selection" argument from eventSelector as it was not needed
- Update all code to adhere to this new way of defining selection and strategy
- Update all code to consistently use the previously introduced returnSplitJobs()